### PR TITLE
餌の種類・濃度に緩急をつけることで地域性を発生させる

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
               Artificial life ecosystem.
             </p>
           </div>
-          <a href="pages/alife_core.html?art_mode=0&population_size=2000&mutation_rate=0.01&single_gene=1&mode=default&field_size=1000"
+          <a href="pages/alife_core.html?art_mode=0&population_size=2000&mutation_rate=0.01&single_gene=1&mode=default&field_size=1600&landscape=1"
             class="parent-element-link"></a>
         </div>
       </div>

--- a/processingjs/droppings.pde
+++ b/processingjs/droppings.pde
@@ -4,17 +4,10 @@ bool mutatingSizeEnabled = true;
 float _backgroundTransparency = null;
 
 void setup() {
+  setLandscapeEnabled();
 	defaultSetup(droppingsEnabled, mutatingSizeEnabled, _backgroundTransparency);
 }
 
-
 void draw() {
 	defaultDraw();
-}
-
-class NotMovingLife extends Life {
-  NotMovingLife(float x, float y, float _size, float _energy, Gene _gene){
-    super(x, y, _size, _energy, _gene);
-  }
-  void move(){}
 }

--- a/processingjs/droppings.pde
+++ b/processingjs/droppings.pde
@@ -4,7 +4,6 @@ bool mutatingSizeEnabled = true;
 float _backgroundTransparency = null;
 
 void setup() {
-  setLandscapeEnabled();
 	defaultSetup(droppingsEnabled, mutatingSizeEnabled, _backgroundTransparency);
 }
 

--- a/processingjs/main.pde
+++ b/processingjs/main.pde
@@ -136,6 +136,14 @@ if (artMode) {
 	console.log("No walls in artistic mode");
 }
 
+// Landscape
+bool landscapeEnabled = false;
+void setLandscapeEnabled() {
+  landscapeEnabled = true;
+  walls = [];
+  console.log("setLandscapeEnabled");
+}
+
 // Color
 float backgroundTransparency = 0xff;
 bool enableEatColor = false;

--- a/processingjs/main.pde
+++ b/processingjs/main.pde
@@ -136,13 +136,6 @@ if (artMode) {
 	console.log("No walls in artistic mode");
 }
 
-// Landscape
-bool landscapeEnabled = false;
-void setLandscapeEnabled() {
-  landscapeEnabled = true;
-  walls = [];
-  console.log("setLandscapeEnabled");
-}
 
 // Color
 float backgroundTransparency = 0xff;
@@ -326,6 +319,49 @@ class Gene {
   String description() {
     return '' + predatorGene + ' | ' + preyGene + ' | ' + droppingsGene + ' | ' + round(size)
   }
+}
+
+// Landscape
+class Landscape {
+  float x;
+  float y;
+  float size;
+  Gene gene;
+  float amount;
+
+  Landscape(float _x, float _y, float _size, Gene _gene, float _amount) {
+    x = _x;
+    y = _y;
+    size = _size;
+    gene = _gene;
+    amount = _amount;
+  }
+}
+bool landscapeEnabled = false;
+Landscape[] landscapes = [];
+float totalAmount = 0.0;
+void setLandscapeEnabled() {
+  console.log("setLandscapeEnabled");
+  landscapeEnabled = true;
+  walls = [];
+  landscapes = [];
+  totalAmount = 0.0;
+
+  int numberOfLandscapes = Math.floor(random(1, populationSize / 400));
+  for (int i = 0; i < numberOfLandscapes; i++) {
+    float x = Math.floor(random(0, fieldWidth));
+    float y = Math.floor(random(0, fieldHeight));
+    float size = Math.floor(random(100, Math.min(fieldWidth, fieldHeight) / 2));
+    Gene gene = Gene.randomGene();
+    float amount = Math.floor(random(1, 100));
+    totalAmount += amount;
+    Landscape landscape = new Landscape(x, y, size, gene, amount);
+    landscapes[landscapes.length] = landscape;
+
+    console.log("(" + x + "," + y + ") " + size + ", " + gene.description() + ", " + amount);
+  }
+
+  console.log("Total " + landscapes.length + " landscapes");
 }
 
 var makeTimer = (function(){

--- a/processingjs/main.pde
+++ b/processingjs/main.pde
@@ -383,9 +383,11 @@ void setLandscapeEnabled() {
   for (int i = 0; i < numberOfLandscapes; i++) {
     float x = Math.floor(random(0, fieldWidth));
     float y = Math.floor(random(0, fieldHeight));
-    float size = Math.floor(random(100, Math.min(fieldWidth, fieldHeight) / 2));
+    float fieldSizeMultipler = Math.min(fieldWidth, fieldHeight) / 4.0;
+    float size = Math.floor(random(100, fieldSizeMultipler));
     Gene gene = Gene.randomGene();
-    float amount = Math.floor(random(1, 100));
+    float maxAmount = (size / fieldSizeMultipler) * 100.0;
+    float amount = Math.floor(random(1, maxAmount));
     landscapeTotalAmount += amount;
     Landscape landscape = new Landscape(x, y, size, gene, amount);
     landscapes[landscapes.length] = landscape;

--- a/processingjs/main.pde
+++ b/processingjs/main.pde
@@ -379,7 +379,7 @@ void setLandscapeEnabled() {
 
   console.log("(" + fieldWidth + "," + fieldHeight + ")");
 
-  int numberOfLandscapes = Math.floor(random(1, populationSize / 300));
+  int numberOfLandscapes = Math.floor(random(10, populationSize / 10));
   for (int i = 0; i < numberOfLandscapes; i++) {
     float x = Math.floor(random(0, fieldWidth));
     float y = Math.floor(random(0, fieldHeight));
@@ -1191,7 +1191,7 @@ void addResourcesOnLandscapes() {
 
     float radius = landscape.size / 2.0;
     float x = random(Math.max(landscape.x - radius, 0), Math.min(landscape.x + radius, fieldWidth));
-    float y = random(Math.max(landscape.y - radius, 0), Math.min(landscape.y + radius, fieldWidth));
+    float y = random(Math.max(landscape.y - radius, 0), Math.min(landscape.y + radius, fieldHeight));
     lifes[lifes.length] = Life.makeResource(x, y, resourceSize, landscape.getGene());
   }
 }

--- a/processingjs/main.pde
+++ b/processingjs/main.pde
@@ -336,7 +336,34 @@ class Landscape {
     gene = _gene;
     amount = _amount;
   }
+
+  Gene getGene() {
+    return gene;
+  }
+
+  String description() {
+    return "(" + x + "," + y + ") " + size + ", " + getGene().description() + ", " + amount;
+  }
 }
+
+class RandomGeneLandscape extends Landscape {
+  RandomGeneLandscape(float _amount) {
+    x = 0;
+    y = 0;
+    size = Math.max(fieldWidth, fieldHeight);
+    gene = null;
+    amount = _amount;
+  }
+
+  Gene getGene() {
+    return Gene.randomGene();
+  }
+
+  String description() {
+    return "Random gene " + amount;
+  }
+}
+
 bool landscapeEnabled = false;
 Landscape[] landscapes = [];
 float landscapeTotalAmount = 0.0;
@@ -345,7 +372,9 @@ void setLandscapeEnabled() {
   landscapeEnabled = true;
   resourceGrowth *= 0.6;
   walls = [];
-  landscapes = [];
+  landscapes = [
+    new RandomGeneLandscape(50)
+  ];
   landscapeTotalAmount = 0.0;
 
   console.log("(" + fieldWidth + "," + fieldHeight + ")");
@@ -361,7 +390,7 @@ void setLandscapeEnabled() {
     Landscape landscape = new Landscape(x, y, size, gene, amount);
     landscapes[landscapes.length] = landscape;
 
-    console.log("(" + x + "," + y + ") " + size + ", " + gene.description() + ", " + amount);
+    console.log(landscape.description());
   }
 
   console.log("Total " + landscapes.length + " landscapes");
@@ -872,8 +901,8 @@ void defaultSetup(bool _droppingsEnabled, bool _mutatingSizeEnabled, float _back
   textFont(fontA, 14);
 
   lifes = [];
-  int paddingWidth =  max(fieldWidth - (initialPopulationFieldSize), 20) / 2;
-  int paddingHeight =  max(fieldHeight - (initialPopulationFieldSize / 4), 20) / 2;
+  int paddingWidth =  0;//max(fieldWidth - (initialPopulationFieldSize), 20) / 2;
+  int paddingHeight =  0;//max(fieldHeight - (initialPopulationFieldSize / 4), 20) / 2;
 
   Gene[] initialGenesArray = [new Gene(0, 0, 0)]; //[Gene.randomGene()];
   for(int i=0; i < populationSize;i++){
@@ -1161,6 +1190,6 @@ void addResourcesOnLandscapes() {
     float radius = landscape.size / 2.0;
     float x = random(Math.max(landscape.x - radius, 0), Math.min(landscape.x + radius, fieldWidth));
     float y = random(Math.max(landscape.y - radius, 0), Math.min(landscape.y + radius, fieldWidth));
-    lifes[lifes.length] = Life.makeResource(x, y, resourceSize, landscape.gene);
+    lifes[lifes.length] = Life.makeResource(x, y, resourceSize, landscape.getGene());
   }
 }

--- a/processingjs/main.pde
+++ b/processingjs/main.pde
@@ -397,6 +397,11 @@ void setLandscapeEnabled() {
 
   console.log("Total " + landscapes.length + " landscapes");
 }
+if (parameters['landscape'] != null) {
+  if (int(parameters['landscape'])) {
+    setLandscapeEnabled();
+  }
+}
 
 var makeTimer = (function(){
   var t = 0;

--- a/processingjs/main.pde
+++ b/processingjs/main.pde
@@ -339,22 +339,25 @@ class Landscape {
 }
 bool landscapeEnabled = false;
 Landscape[] landscapes = [];
-float totalAmount = 0.0;
+float landscapeTotalAmount = 0.0;
 void setLandscapeEnabled() {
   console.log("setLandscapeEnabled");
   landscapeEnabled = true;
+  resourceGrowth *= 0.6;
   walls = [];
   landscapes = [];
-  totalAmount = 0.0;
+  landscapeTotalAmount = 0.0;
 
-  int numberOfLandscapes = Math.floor(random(1, populationSize / 400));
+  console.log("(" + fieldWidth + "," + fieldHeight + ")");
+
+  int numberOfLandscapes = Math.floor(random(1, populationSize / 300));
   for (int i = 0; i < numberOfLandscapes; i++) {
     float x = Math.floor(random(0, fieldWidth));
     float y = Math.floor(random(0, fieldHeight));
     float size = Math.floor(random(100, Math.min(fieldWidth, fieldHeight) / 2));
     Gene gene = Gene.randomGene();
     float amount = Math.floor(random(1, 100));
-    totalAmount += amount;
+    landscapeTotalAmount += amount;
     Landscape landscape = new Landscape(x, y, size, gene, amount);
     landscapes[landscapes.length] = landscape;
 
@@ -1102,7 +1105,11 @@ var timer = makeTimer();
 
 void addResources() {
   if(populationOfResource > maxResourceSize) {
-    return
+    return;
+  }
+  if (landscapeEnabled) {
+    addResourcesOnLandscapes();
+    return;
   }
   int numberOfResources = int(random(0, resourceGrowth));
 //  Gene g = new Gene(0, 0, 0);
@@ -1130,5 +1137,30 @@ void addResources() {
 						}
       lifes[lifes.length] = Life.makeResource(position.x, position.y, resourceSize, Gene.randomGene());
     }
+  }
+}
+
+void addResourcesOnLandscapes() {
+  int numberOfResources = int(random(0, resourceGrowth));
+
+  for (int i = 0; i < numberOfResources; i++) {
+    float selection = random(landscapeTotalAmount);
+    Landscape landscape;
+    for (int j = 0; j < landscapes.length; j++) {
+      if (selection < landscapes[j].amount) {
+        landscape = landscapes[j];
+        break;
+      }
+      selection -= landscapes[j].amount;
+    }
+    if (landscape == null) {
+      console.log("バグがあります");
+      continue;
+    }
+
+    float radius = landscape.size / 2.0;
+    float x = random(Math.max(landscape.x - radius, 0), Math.min(landscape.x + radius, fieldWidth));
+    float y = random(Math.max(landscape.y - radius, 0), Math.min(landscape.y + radius, fieldWidth));
+    lifes[lifes.length] = Life.makeResource(x, y, resourceSize, landscape.gene);
   }
 }


### PR DESCRIPTION
# 概要

- フィールド上に複数の領域が置かれる
  - それぞれの領域は位置と大きさをもち、出現する餌の種類・量が設定されている
  - 種類はとりあえずひとつずつでいいか

# 観察結果

- 地域性は生まれている
- 安定した生態系は生まれていない
  - 最終的には絶滅する→餌の溜まったLandscapeに捕食者が迷い込むと一気に増殖し、餌がなくなると死滅して他へ移っている→それを繰り返すと確率で全ての個体が死亡する
  - 餌を食べ尽くして絶滅したりしている→エネルギー消費と生産高が釣り合うような調整を入れる？

# Future Work

- 繁殖のインターバルをもうけることで安定させる
  - ある種のうごきに他の種が反応できるインターバルをもうける

# Gallery

![1609002085__00022200](https://user-images.githubusercontent.com/904354/103272810-202a5500-4a01-11eb-9bce-0284b7913deb.png)
